### PR TITLE
Upgrade detect changes

### DIFF
--- a/cli/lib/detect-changes.js
+++ b/cli/lib/detect-changes.js
@@ -1,0 +1,85 @@
+const parseGitIgnore = require('parse-gitignore');
+const {Minimatch} = require('minimatch');
+const shelljs = require('shelljs');
+const fs = require('fs');
+const path = require('path');
+const inDir = require('./in-dir');
+const _ = require('lodash');
+
+const targetFileSentinelFilename = 'target/.bibuild-sentinel';
+
+exports.makePackageBuilt = function (dir) {
+  shelljs.mkdir('-p', path.resolve(dir, path.dirname(targetFileSentinelFilename)));
+  fs.writeFileSync(path.resolve(dir, targetFileSentinelFilename), '');
+};
+
+
+exports.makePackageUnbuilt = makePackageUnbuilt;
+function makePackageUnbuilt(dir) {
+  shelljs.rm('-f', path.resolve(dir, targetFileSentinelFilename));
+}
+
+exports.makePackagesUnbuilt = function (dirs) {
+  dirs.forEach(makePackageUnbuilt);
+};
+
+exports.findChangedPackages = (dir, packages) => inDir(dir, () => packages.filter(p => isPackageChanged(p)))
+
+
+function createIgnoreFn(ignores) {
+  const patterns = parseGitIgnore.parse(ignores, {})
+  const matchers = patterns.map(pattern => new Minimatch(pattern))
+  return filePath => matchers.some(matcher => matcher.match(filePath))
+}
+
+function isPackageChanged(packageObject) {
+  const fullPath = packageObject.fullPath;
+  let ignores = collectIgnores(fullPath, []);
+  const ignored = createIgnoreFn(ignores);
+  const targetSentinelForPackage = path.resolve(fullPath, targetFileSentinelFilename);
+  return !shelljs.test('-f', targetSentinelForPackage) ||
+    modifiedAfter(packageObject.fullPath, '.', ignored, fs.statSync(targetSentinelForPackage).mtime.getTime())
+}
+
+function modifiedAfter(baseDir, dir, ignored, timeStamp) {
+  let rootAbsolutePath = path.resolve(baseDir, dir);
+  const entries = shelljs.ls(rootAbsolutePath);
+
+  return entries
+    .map(entry => {
+      const absolutePath = path.resolve(rootAbsolutePath, entry);
+      return {
+        absolutePath,
+        relativePath: path.relative(baseDir, absolutePath),
+        stats: fs.lstatSync(absolutePath)
+      }
+    })
+    .filter(({relativePath}) => !ignored(relativePath))
+    .filter(({stats}) => !stats.isSymbolicLink())
+    .sort(({stats}) => stats.isFile() ? -1 : 1)
+    .some(({relativePath, stats}) => {
+      return stats.isDirectory() ? modifiedAfter(baseDir, relativePath, ignored, timeStamp) : stats.mtime.getTime() > timeStamp
+    })
+
+}
+
+function collectIgnores(dir, acc) {
+  acc = acc || ['target', 'node_modules', 'npm-debug.log'];
+  return _.union(acc, inDir(dir, () => {
+    const slash = path.sep;
+    const ignores = readAndParseGitignore();
+    const parent = dir.split(slash).slice(0, -1).join(slash) || '/';
+    const isRoot = shelljs.test('-d', '.git');
+    return isRoot || dir === slash ? ignores : collectIgnores(parent, ignores);
+  }));
+}
+
+function readAndParseGitignore() {
+  const gitignore = shelljs.test('-f', '.gitignore');
+  return gitignore
+    ? fs.readFileSync('.gitignore', 'utf8')
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line && line.charAt(0) !== '#')
+    : [];
+}

--- a/cli/lib/in-dir.js
+++ b/cli/lib/in-dir.js
@@ -1,0 +1,10 @@
+module.exports = function inDir(dir, f) {
+  const originalDir = process.cwd();
+  process.chdir(dir);
+  try {
+    return f();
+  }
+  finally {
+    process.chdir(originalDir);
+  }
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -31,10 +31,11 @@
     "findup-sync": "~0.4.3",
     "graphlib": "^2.1.1",
     "handlebars": "~4.0.6",
-    "ignore-file": "~1.1.2",
     "jsondiffpatch": "~0.2.4",
     "lodash": "~4.17.4",
+    "minimatch": "^3.0.3",
     "object-filter": "~1.0.2",
+    "parse-gitignore": "^0.3.1",
     "shelljs": "~0.7.5",
     "yargs": "~6.6.0"
   },

--- a/cli/test/octo-modules.spec.js
+++ b/cli/test/octo-modules.spec.js
@@ -144,7 +144,9 @@ describe('octo-modules', function () {
           expect(out).to.be.string('b (b) (1/1)');
           expect(out).to.be.string('a: ~1.0.0 -> ~2.0.0');
 
-          expect(ctx.exec('git status')).to.be.string('nothing to commit, working directory clean');
+          // git v2.9.1 changed the output of git status, 
+          // see https://github.com/git/git/blob/e0c1ceafc5bece92d35773a75fff59497e1d9bd5/Documentation/RelNotes/2.9.1.txt#L53
+          expect(ctx.exec('git status')).to.match(/nothing to commit, working (directory|tree) clean/);
           done();
         }
       });


### PR DESCRIPTION
Currently, the way changes are detected is sub optimal: we first scan all the files in the package folder to find the latest updated file timestamp and then compare it to the timestamp of the build marker. This PR aborts the search process on first file modified after the build marker. 

Also, the tests don't work on git v2.11.1, so I added a fix for that 